### PR TITLE
Adjusted build script and Dockerfile to work with InfluxDB 2.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,26 @@
 FROM alpine:3.10 as builder
 
-ARG VERSION=1.8.10
+ARG VERSION=2.1.1
 ARG ARCH=amd64
-ARG STATIC=-static
 
-RUN wget https://dl.influxdata.com/influxdb/releases/influxdb-${VERSION}${STATIC}_linux_${ARCH}.tar.gz && \
-    tar xvfz influxdb-${VERSION}${STATIC}_linux_${ARCH}.tar.gz && \
-    rm -f influxdb-${VERSION}${STATIC}_linux_${ARCH}.tar.gz && \
-    ([ -f influxdb-${VERSION}-1/influxd ] && cp influxdb-${VERSION}-1/influxd /root || cp influxdb-${VERSION}-1/usr/bin/influxd /root) && \
-    rm -rf influxdb-${VERSION}-1
+RUN wget https://dl.influxdata.com/influxdb/releases/influxdb2-${VERSION}-linux-${ARCH}.tar.gz && \
+    tar xvfz influxdb2-${VERSION}-linux-${ARCH}.tar.gz && \
+    rm -f influxdb2-${VERSION}-linux-${ARCH}.tar.gz && \
+    ([ -f influxdb2-${VERSION}-linux-${ARCH}/influxd ] && cp influxdb2-${VERSION}-linux-${ARCH}/influxd /root || cp influxdb2-${VERSION}-linux-${ARCH}/usr/bin/influxd /root) && \
+    rm -rf influxdb2-${VERSION}-linux-${ARCH}
 
-RUN wget https://raw.githubusercontent.com/influxdata/influxdb/v${VERSION}/LICENSE
-RUN wget https://raw.githubusercontent.com/influxdata/influxdb/v${VERSION}/DEPENDENCIES.md && \
+RUN wget https://raw.githubusercontent.com/influxdata/influxdb/v${VERSION}/LICENSE && \
 echo "" >> LICENSE && \
 echo "" >> LICENSE && \
 echo "--------------------------------------------------------------" >> LICENSE && \
 echo "# Dependencies compiled into the binary as stated by InfluxDB" >> LICENSE && \
 echo "" >> LICENSE && \
-echo "" >> LICENSE && \
-cat DEPENDENCIES.md >> LICENSE
+echo "" >> LICENSE
 RUN mv LICENSE influxdb-${VERSION}
-RUN mkdir -p /root/tmp && cp /root/influxd /root/tmp && mkdir /root/tmp/.influxdb && chown -R 65534:65534 /root/tmp 
+RUN mkdir -p /root/tmp && cp /root/influxd /root/tmp && mkdir /root/tmp/.influxdbv2 && chown -R 65534:65534 /root/tmp 
 
 FROM scratch as image
-ARG VERSION=1.8.10
+ARG VERSION=2.1.1
 USER 65534:65534
 COPY --from=builder /root/tmp/ /
 COPY --from=builder /influxdb-${VERSION} /licenses/influxdb-${VERSION}

--- a/build.sh
+++ b/build.sh
@@ -1,19 +1,15 @@
-VERSION=1.8.10
+VERSION=2.1.1
 DOCKERHUB=docker.io/distrolessdocker/distroless-influxdb
 
-docker buildx build --build-arg VERSION=$VERSION --platform linux/amd64 --build-arg ARCH=amd64 --build-arg STATIC=-static -t $DOCKERHUB:amd64-$VERSION .
-docker buildx build --build-arg VERSION=$VERSION --platform linux/arm/v7 --build-arg ARCH=armhf --build-arg STATIC= -t $DOCKERHUB:armhf-$VERSION .
-docker buildx build --build-arg VERSION=$VERSION --platform linux/arm64/v8 --build-arg ARCH=arm64 --build-arg STATIC= -t $DOCKERHUB:arm64-$VERSION .
+docker buildx build --build-arg VERSION=$VERSION --platform linux/amd64 --build-arg ARCH=amd64 -t $DOCKERHUB:amd64-$VERSION .
+docker buildx build --build-arg VERSION=$VERSION --platform linux/arm64/v8 --build-arg ARCH=arm64 -t $DOCKERHUB:arm64-$VERSION .
 docker push $DOCKERHUB:amd64-$VERSION
-docker push $DOCKERHUB:armhf-$VERSION
 docker push $DOCKERHUB:arm64-$VERSION
 docker rmi $DOCKERHUB:amd64-$VERSION
-docker rmi $DOCKERHUB:armhf-$VERSION
 docker rmi $DOCKERHUB:arm64-$VERSION
 
-DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend $DOCKERHUB:$VERSION $DOCKERHUB:amd64-$VERSION $DOCKERHUB:armhf-$VERSION $DOCKERHUB:arm64-$VERSION
+DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend $DOCKERHUB:$VERSION $DOCKERHUB:amd64-$VERSION $DOCKERHUB:arm64-$VERSION
 
 DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate $DOCKERHUB:$VERSION $DOCKERHUB:amd64-$VERSION --os linux --arch amd64
-DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate $DOCKERHUB:$VERSION $DOCKERHUB:armhf-$VERSION --os linux --arch arm --variant v7
 DOCKER_CLI_EXPERIMENTAL=enabled docker manifest annotate $DOCKERHUB:$VERSION $DOCKERHUB:arm64-$VERSION --os linux --arch arm64 --variant v8
 DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push $DOCKERHUB:$VERSION


### PR DESCRIPTION
- Adjusted version
- Removed static (not needed anymore)
- Removed DEPENDENCIES.md (not available anymore)
- Removed linux/arm/v7 (not possible for InfluxDB >= 2.0